### PR TITLE
Added a gitVersion property to use different maven and git versions

### DIFF
--- a/src/main/groovy/org/batcha/gradle/plugins/gitDependencies/ResolveGitDependenciesTask.groovy
+++ b/src/main/groovy/org/batcha/gradle/plugins/gitDependencies/ResolveGitDependenciesTask.groovy
@@ -76,11 +76,17 @@ class ResolveGitDependenciesTask extends DefaultTask {
     //resolve the dependencies found
     for (ExternalModuleDependency d : dependencies) {
 
-      logger.info("Git dependency found for " + d.name + " " + d.version + " " + d.git)
+      def gitVersion = d.version
+
+      if (d.hasProperty("gitVersion")) {
+        gitVersion = d.gitVersion
+      }
+
+      logger.info("Git dependency found for " + d.name + " " + d.version + " " + d.git + "[version/branch: " + gitVersion + "]")
 
       def destination = new File(project.gitDependenciesDir + File.separator + d.name)
 
-      refreshGitRepository(d.git, d.version, destination)
+      refreshGitRepository(d.git, gitVersion, destination)
     }
   }
   


### PR DESCRIPTION
This patch allows to specifiy another version or branch in the git repository than specified with the dependency.

```
compile('org.batcha.gradle.plugins:git-dependencies:0.1') {
    ext.git = 'https://github.com/bat-cha/gradle-plugin-git-dependencies.git'
    ext.gitVersion = 'some/otherBranch'
}
```

Since I'm fairly new to gradle I don't know if this is redudant and the functionality was already available elsewhere.  This however solved my problem with a discrepancy between maven and git version for the moment ;-)
