### PR TITLE
Prevent errors when trying to create a branch that already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ bin
 .classpath
 .settings
 
+# intellij
+.idea
+*.iml
+local.properties
+
 # log
 *.log*
 

--- a/src/main/groovy/org/batcha/gradle/plugins/git/InitGitDependenciesTask.groovy
+++ b/src/main/groovy/org/batcha/gradle/plugins/git/InitGitDependenciesTask.groovy
@@ -57,8 +57,6 @@ class InitGitDependenciesTask extends DefaultTask {
     }
   }
 
-
-
   def init(Project project, Multimap<ExternalModuleDependency, Configuration> gitDependencies) {
 
     //resolve the dependencies found
@@ -70,5 +68,4 @@ class InitGitDependenciesTask extends DefaultTask {
 
     }
   }
-
 }

--- a/src/main/groovy/org/batcha/gradle/plugins/git/RefreshGitDependenciesTask.groovy
+++ b/src/main/groovy/org/batcha/gradle/plugins/git/RefreshGitDependenciesTask.groovy
@@ -55,7 +55,4 @@ class RefreshGitDependenciesTask extends DefaultTask {
 
     }
   }
-
-
-
 }

--- a/src/main/groovy/org/batcha/gradle/plugins/git/ResolveGitDependenciesTask.groovy
+++ b/src/main/groovy/org/batcha/gradle/plugins/git/ResolveGitDependenciesTask.groovy
@@ -43,7 +43,7 @@ class ResolveGitDependenciesTask extends DefaultTask {
   }
 
   /**
-   * Iterates trough dependencies specification and resolve the Git-Dependencies.
+   * Iterates through dependencies specification and resolve the Git-Dependencies.
    */
   @TaskAction
   def resolveDependencies() {

--- a/src/main/groovy/org/batcha/gradle/plugins/git/dependencies/GitHelper.groovy
+++ b/src/main/groovy/org/batcha/gradle/plugins/git/dependencies/GitHelper.groovy
@@ -75,12 +75,18 @@ class GitHelper {
       }
       cmd.setName(version)
     } else {
-      cmd.setCreateBranch(true)
       RevWalk revWalk = new RevWalk(repo.getRepository())
       ObjectId id = repo.getRepository().resolve(version)
       if (id == null) {
+        if(!branchesLocal.contains("master")) {
+          cmd.setCreateBranch(true)
+        }
         cmd.setName("master")
       } else {
+        if(!branchesLocal.contains(version)) {
+          cmd.setCreateBranch(true)
+        }
+
         RevCommit commit = revWalk.parseCommit(id)
         cmd.setStartPoint(commit)
         cmd.setName(version)

--- a/src/main/groovy/org/batcha/gradle/plugins/git/dependencies/GradleDependenciesHelper.groovy
+++ b/src/main/groovy/org/batcha/gradle/plugins/git/dependencies/GradleDependenciesHelper.groovy
@@ -156,5 +156,4 @@ class GradleDependenciesHelper {
     GitHelper.checkoutVersion(destinationDir, gitVersion)
 
   }
-
 }


### PR DESCRIPTION
I was occasionally getting an error when resolving dependancies that used a sha saying a branch already existed. This just adds an additional check before adding the createBranch option.  
